### PR TITLE
Track exercise progress over time with volume metric

### DIFF
--- a/src/main/java/com/faiyaz/project/fittrack/exercise/controller/ExerciseController.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/controller/ExerciseController.java
@@ -1,15 +1,19 @@
 package com.faiyaz.project.fittrack.exercise.controller;
 
+import com.faiyaz.project.fittrack.exercise.dto.ExerciseProgressResponseDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseRequestDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseResponseDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseUpdateRequestDto;
 import com.faiyaz.project.fittrack.exercise.service.ExerciseService;
 import com.faiyaz.project.fittrack.user.entity.User;
+import org.apache.coyote.Response;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,5 +46,18 @@ public class ExerciseController {
                                             @AuthenticationPrincipal User user) throws AccessDeniedException {
         exerciseService.deleteExercise(id, user.getId());
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/progress")
+    public ResponseEntity<List<ExerciseProgressResponseDto>> getExerciseProgress(
+            @AuthenticationPrincipal User user,
+            @RequestParam String name,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate endDate
+    ) {
+        List<ExerciseProgressResponseDto> response = exerciseService.getExerciseProgress(user.getId(), name, startDate, endDate);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseProgressResponseDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseProgressResponseDto.java
@@ -1,0 +1,19 @@
+package com.faiyaz.project.fittrack.exercise.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ExerciseProgressResponseDto {
+    private LocalDate date;
+    private String name;
+    private int sets;
+    private int reps;
+    private double weight;
+    private double volume;
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/repository/ExerciseRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -16,4 +17,6 @@ public interface ExerciseRepository extends JpaRepository<Exercise, UUID> {
     void deleteByWorkoutId(UUID workoutId);
 
     List<Exercise> findByWorkoutId(UUID workoutId);
+
+    List<Exercise> findByWorkout_User_IdAndNameAndWorkout_SessionDateBetweenOrderByWorkout_SessionDateAsc(UUID userId, String name, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/service/ExerciseService.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/service/ExerciseService.java
@@ -1,5 +1,6 @@
 package com.faiyaz.project.fittrack.exercise.service;
 
+import com.faiyaz.project.fittrack.exercise.dto.ExerciseProgressResponseDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseRequestDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseResponseDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseUpdateRequestDto;
@@ -12,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.nio.file.AccessDeniedException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -102,5 +104,26 @@ public class ExerciseService {
         }
 
         exerciseRepository.delete(existingExercise);
+    }
+
+    public List<ExerciseProgressResponseDto> getExerciseProgress(UUID userId, String name, LocalDate startDate, LocalDate endDate) {
+        List<Exercise> exercises = exerciseRepository.findByWorkout_User_IdAndNameAndWorkout_SessionDateBetweenOrderByWorkout_SessionDateAsc(
+                userId,
+                name,
+                startDate != null ? startDate : LocalDate.of(1970, 1, 1),
+                endDate != null ? endDate : LocalDate.now()
+        );
+
+        List<ExerciseProgressResponseDto> response = exercises.stream().map(e -> ExerciseProgressResponseDto.builder()
+                .date(e.getWorkout().getSessionDate())
+                .name(e.getName())
+                .sets(e.getSets())
+                .reps(e.getReps())
+                .weight(e.getWeight())
+                .volume(e.getSets()*e.getReps()*e.getWeight())
+                .build())
+                .toList();
+
+        return response;
     }
 }


### PR DESCRIPTION
Added endpoint to fetch progress for a specific exercise filtered by date range.
Response includes calculated volume (sets * reps * weight) to visualize growth.
Supports query params for name, startDate, and endDate.
