### PR TITLE
Refactor Exercise Entity for Catalog and Custom Exercises

### DIFF
--- a/src/main/java/com/faiyaz/project/fittrack/config/DataSeeder.java
+++ b/src/main/java/com/faiyaz/project/fittrack/config/DataSeeder.java
@@ -1,0 +1,68 @@
+package com.faiyaz.project.fittrack.config;
+
+import com.faiyaz.project.fittrack.exercise.entity.ExerciseCatalog;
+import com.faiyaz.project.fittrack.exercise.entity.MuscleGroup;
+import com.faiyaz.project.fittrack.exercise.repository.ExerciseCatalogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataSeeder {
+
+    private final ExerciseCatalogRepository catalogRepository;
+
+    @Bean
+    public CommandLineRunner seedExerciseCatalog(){
+        return args -> {
+            if (catalogRepository.count() == 0) {
+                List<ExerciseCatalog> catalogEntries = List.of(
+                        // Chest
+                        new ExerciseCatalog(null, "Barbell Bench Press", MuscleGroup.CHEST, true),
+                        new ExerciseCatalog(null, "Incline Dumbbell Press", MuscleGroup.CHEST, true),
+                        new ExerciseCatalog(null, "Chest Fly Machine", MuscleGroup.CHEST, true),
+                        new ExerciseCatalog(null, "Push Ups", MuscleGroup.CHEST, true),
+
+                        // Back
+                        new ExerciseCatalog(null, "Pull Ups", MuscleGroup.BACK, true),
+                        new ExerciseCatalog(null, "Lat Pulldown", MuscleGroup.BACK, true),
+                        new ExerciseCatalog(null, "Barbell Rows", MuscleGroup.BACK, true),
+                        new ExerciseCatalog(null, "Seated Cable Rows", MuscleGroup.BACK, true),
+
+                        // Shoulders
+                        new ExerciseCatalog(null, "Overhead Press", MuscleGroup.SHOULDERS, true),
+                        new ExerciseCatalog(null, "Lateral Raises", MuscleGroup.SHOULDERS, true),
+                        new ExerciseCatalog(null, "Front Raises", MuscleGroup.SHOULDERS, true),
+                        new ExerciseCatalog(null, "Reverse Pec Deck", MuscleGroup.SHOULDERS, true),
+
+                        // Arms
+                        new ExerciseCatalog(null, "Barbell Bicep Curl", MuscleGroup.BICEPS, true),
+                        new ExerciseCatalog(null, "Dumbbell Hammer Curl", MuscleGroup.BICEPS, true),
+                        new ExerciseCatalog(null, "Tricep Pushdown", MuscleGroup.TRICEPS, true),
+                        new ExerciseCatalog(null, "Skull Crushers", MuscleGroup.TRICEPS, true),
+
+                        // Legs
+                        new ExerciseCatalog(null, "Barbell Squat", MuscleGroup.LEGS, true),
+                        new ExerciseCatalog(null, "Leg Press", MuscleGroup.LEGS, true),
+                        new ExerciseCatalog(null, "Romanian Deadlift", MuscleGroup.LEGS, true),
+                        new ExerciseCatalog(null, "Lunges", MuscleGroup.LEGS, true),
+                        new ExerciseCatalog(null, "Leg Curl Machine", MuscleGroup.LEGS, true),
+                        new ExerciseCatalog(null, "Leg Extension Machine", MuscleGroup.LEGS, true),
+
+                        // Core
+                        new ExerciseCatalog(null, "Plank", MuscleGroup.CORE, true),
+                        new ExerciseCatalog(null, "Hanging Leg Raises", MuscleGroup.CORE, true),
+                        new ExerciseCatalog(null, "Cable Crunch", MuscleGroup.CORE, true),
+                        new ExerciseCatalog(null, "Russian Twists", MuscleGroup.CORE, true)
+                );
+
+                catalogRepository.saveAll(catalogEntries);
+                System.out.println("Seeded global ExerciseCatalog.");
+            }
+        };
+    }
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/controller/CustomExerciseController.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/controller/CustomExerciseController.java
@@ -1,0 +1,34 @@
+package com.faiyaz.project.fittrack.exercise.controller;
+
+import com.faiyaz.project.fittrack.exercise.dto.CustomExerciseRequestDto;
+import com.faiyaz.project.fittrack.exercise.dto.CustomExerciseResponseDto;
+import com.faiyaz.project.fittrack.exercise.service.CustomExerciseService;
+import com.faiyaz.project.fittrack.user.entity.User;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/custom-exercises")
+public class CustomExerciseController {
+
+    private final CustomExerciseService customExerciseService;
+
+    public CustomExerciseController(CustomExerciseService customExerciseService) {
+        this.customExerciseService = customExerciseService;
+    }
+
+    @PostMapping
+    public ResponseEntity<CustomExerciseResponseDto> create(@RequestBody CustomExerciseRequestDto request,
+                                                            @AuthenticationPrincipal User user){
+        return ResponseEntity.ok(customExerciseService.createCustomExercise(request, user));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CustomExerciseResponseDto>> getAll(@AuthenticationPrincipal User user){
+        return ResponseEntity.ok(customExerciseService.getAll(user));
+    }
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/CustomExerciseRequestDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/CustomExerciseRequestDto.java
@@ -1,0 +1,17 @@
+package com.faiyaz.project.fittrack.exercise.dto;
+
+import com.faiyaz.project.fittrack.exercise.entity.MuscleGroup;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomExerciseRequestDto {
+
+    private String name;
+    private MuscleGroup muscleGroup;
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/CustomExerciseResponseDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/CustomExerciseResponseDto.java
@@ -1,0 +1,21 @@
+package com.faiyaz.project.fittrack.exercise.dto;
+
+import com.faiyaz.project.fittrack.exercise.entity.MuscleGroup;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomExerciseResponseDto {
+
+    private UUID id;
+    private String name;
+    private MuscleGroup muscleGroup;
+
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseRequestDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseRequestDto.java
@@ -23,10 +23,10 @@ public class ExerciseRequestDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class ExerciseInput {
-        private String name;
+        private UUID catalogId;
+        private UUID customId;
         private int sets;
         private int reps;
         private double weight;
-        private MuscleGroup muscleGroup;
     }
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseUpdateRequestDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseUpdateRequestDto.java
@@ -6,14 +6,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExerciseUpdateRequestDto {
-    private String name;
+    private UUID catalogId;
+    private UUID customId;
     private Integer sets;
     private Integer reps;
     private Double weight;
-    private MuscleGroup muscleGroup;
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/entity/CustomExercise.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/entity/CustomExercise.java
@@ -1,0 +1,32 @@
+package com.faiyaz.project.fittrack.exercise.entity;
+
+import com.faiyaz.project.fittrack.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_custom_exercises")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomExercise {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private MuscleGroup muscleGroup;
+
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/entity/Exercise.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/entity/Exercise.java
@@ -26,8 +26,16 @@ public class Exercise {
     @JoinColumn(name = "workout_id", nullable = false)
     private Workout workout;
 
-    @Column(nullable = false)
-    private String name;
+//    @Column(nullable = false)
+//    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "catalog_id")
+    private ExerciseCatalog exerciseCatalog;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "custom_id")
+    private CustomExercise customExercise;
 
     @Column(nullable = false)
     private int sets;
@@ -38,9 +46,9 @@ public class Exercise {
     @Column(nullable = false)
     private double weight;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private MuscleGroup muscleGroup;
+//    @Enumerated(EnumType.STRING)
+//    @Column(nullable = false)
+//    private MuscleGroup muscleGroup;
 
     @CreationTimestamp
     private LocalDateTime createdAt;

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/entity/ExerciseCatalog.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/entity/ExerciseCatalog.java
@@ -1,0 +1,32 @@
+package com.faiyaz.project.fittrack.exercise.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "exercise_catalog")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExerciseCatalog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MuscleGroup muscleGroup;
+
+    @Column(nullable = false)
+    private boolean isGlobal = true;
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/repository/CustomExerciseRepository.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/repository/CustomExerciseRepository.java
@@ -1,0 +1,9 @@
+package com.faiyaz.project.fittrack.exercise.repository;
+
+import com.faiyaz.project.fittrack.exercise.entity.CustomExercise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CustomExerciseRepository extends JpaRepository<CustomExercise, UUID> {
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/repository/CustomExerciseRepository.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/repository/CustomExerciseRepository.java
@@ -1,9 +1,14 @@
 package com.faiyaz.project.fittrack.exercise.repository;
 
 import com.faiyaz.project.fittrack.exercise.entity.CustomExercise;
+import com.faiyaz.project.fittrack.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
+@Repository
 public interface CustomExerciseRepository extends JpaRepository<CustomExercise, UUID> {
+    List<CustomExercise> findByUser(User user);
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/repository/ExerciseCatalogRepository.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/repository/ExerciseCatalogRepository.java
@@ -1,0 +1,11 @@
+package com.faiyaz.project.fittrack.exercise.repository;
+
+import com.faiyaz.project.fittrack.exercise.entity.ExerciseCatalog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ExerciseCatalogRepository extends JpaRepository<ExerciseCatalog, UUID> {
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/repository/ExerciseRepository.java
@@ -12,11 +12,22 @@ import java.util.UUID;
 @Repository
 public interface ExerciseRepository extends JpaRepository<Exercise, UUID> {
 
-    List<Exercise> findByWorkout_User_IdAndNameOrderByWorkout_SessionDateAsc(UUID userId, String name);
+    //List<Exercise> findByWorkout_User_IdAndNameOrderByWorkout_SessionDateAsc(UUID userId, String name);
     @Transactional
     void deleteByWorkoutId(UUID workoutId);
 
     List<Exercise> findByWorkoutId(UUID workoutId);
 
-    List<Exercise> findByWorkout_User_IdAndNameAndWorkout_SessionDateBetweenOrderByWorkout_SessionDateAsc(UUID userId, String name, LocalDate startDate, LocalDate endDate);
+    List<Exercise> findByWorkout_User_IdAndExerciseCatalog_NameAndWorkout_SessionDateBetweenOrderByWorkout_SessionDateAsc(
+            UUID userId,
+            String name,
+            LocalDate startDate,
+            LocalDate endDate);
+    List<Exercise> findByWorkout_User_IdAndCustomExercise_NameAndWorkout_SessionDateBetweenOrderByWorkout_SessionDateAsc(
+            UUID userId,
+            String name,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/service/CustomExerciseService.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/service/CustomExerciseService.java
@@ -1,0 +1,38 @@
+package com.faiyaz.project.fittrack.exercise.service;
+
+import com.faiyaz.project.fittrack.exercise.dto.CustomExerciseRequestDto;
+import com.faiyaz.project.fittrack.exercise.dto.CustomExerciseResponseDto;
+import com.faiyaz.project.fittrack.exercise.entity.CustomExercise;
+import com.faiyaz.project.fittrack.exercise.repository.CustomExerciseRepository;
+import com.faiyaz.project.fittrack.user.entity.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CustomExerciseService {
+
+    private final CustomExerciseRepository customExerciseRepository;
+
+    public CustomExerciseService(CustomExerciseRepository customExerciseRepository) {
+        this.customExerciseRepository = customExerciseRepository;
+    }
+
+    public CustomExerciseResponseDto createCustomExercise(CustomExerciseRequestDto request, User user) {
+        CustomExercise customExercise = CustomExercise.builder()
+                .name(request.getName())
+                .user(user)
+                .muscleGroup(request.getMuscleGroup())
+                .build();
+
+        CustomExercise saved = customExerciseRepository.save(customExercise);
+
+        return new CustomExerciseResponseDto(saved.getId(), saved.getName(), saved.getMuscleGroup());
+    }
+
+    public List<CustomExerciseResponseDto> getAll(User user) {
+        return customExerciseRepository.findByUser(user).stream()
+                .map(e -> new CustomExerciseResponseDto(e.getId(), e.getName(), e.getMuscleGroup()))
+                .toList();
+    }
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/service/ExerciseService.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/service/ExerciseService.java
@@ -4,7 +4,12 @@ import com.faiyaz.project.fittrack.exercise.dto.ExerciseProgressResponseDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseRequestDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseResponseDto;
 import com.faiyaz.project.fittrack.exercise.dto.ExerciseUpdateRequestDto;
+import com.faiyaz.project.fittrack.exercise.entity.CustomExercise;
 import com.faiyaz.project.fittrack.exercise.entity.Exercise;
+import com.faiyaz.project.fittrack.exercise.entity.ExerciseCatalog;
+import com.faiyaz.project.fittrack.exercise.entity.MuscleGroup;
+import com.faiyaz.project.fittrack.exercise.repository.CustomExerciseRepository;
+import com.faiyaz.project.fittrack.exercise.repository.ExerciseCatalogRepository;
 import com.faiyaz.project.fittrack.exercise.repository.ExerciseRepository;
 import com.faiyaz.project.fittrack.user.repository.UserRepository;
 import com.faiyaz.project.fittrack.workout.entity.Workout;
@@ -25,10 +30,17 @@ public class ExerciseService {
 
     private final ExerciseRepository exerciseRepository;
     private final WorkoutRepository workoutRepository;
+    private final ExerciseCatalogRepository exerciseCatalogRepository;
+    private final CustomExerciseRepository customExerciseRepository;
 
-    public ExerciseService(ExerciseRepository exerciseRepository, WorkoutRepository workoutRepository) {
+    public ExerciseService(ExerciseRepository exerciseRepository, WorkoutRepository workoutRepository,
+                           ExerciseCatalogRepository exerciseCatalogRepository,
+                           CustomExerciseRepository customExerciseRepository
+                           ) {
         this.exerciseRepository = exerciseRepository;
         this.workoutRepository = workoutRepository;
+        this.exerciseCatalogRepository = exerciseCatalogRepository;
+        this.customExerciseRepository = customExerciseRepository;
     }
 
     public List<ExerciseResponseDto> addExerciseToWorkout(ExerciseRequestDto request){
@@ -36,29 +48,54 @@ public class ExerciseService {
                 .orElseThrow(() -> new IllegalArgumentException("Workout not found"));
 
         List<Exercise> exercises = request.getExercises().stream()
-                .map(ex -> Exercise.builder()
-                        .workout(workout)
-                        .name(ex.getName())
-                        .sets(ex.getSets())
-                        .reps(ex.getReps())
-                        .weight(ex.getWeight())
-                        .muscleGroup(ex.getMuscleGroup())
-                        .build())
-                .collect(Collectors.toList());
+                .map(ex -> {
+                    ExerciseCatalog catalog = null;
+                    CustomExercise custom = null;
+
+                    if(ex.getCustomId() != null && ex.getCatalogId() != null){
+                        throw new IllegalArgumentException("Only one of catalogId or customId must be provided.");
+                    }
+
+                    if(ex.getCatalogId() != null){
+                        catalog = exerciseCatalogRepository.findById(ex.getCatalogId())
+                                .orElseThrow(() -> new NoSuchElementException("Catalog exercise not found"));
+                    } else if(ex.getCustomId() != null){
+                        custom = customExerciseRepository.findById(ex.getCustomId())
+                                .orElseThrow(()-> new NoSuchElementException("Custom exercise not found"));
+                    } else {
+                        throw new IllegalArgumentException("Either catalogId or customId must be provided.");
+                    }
+
+                   return Exercise.builder()
+                            .workout(workout)
+                            .exerciseCatalog(catalog)
+                            .customExercise(custom)
+                            .sets(ex.getSets())
+                            .reps(ex.getReps())
+                            .weight(ex.getWeight())
+                            .build();
+                }).collect(Collectors.toList());
 
         List<Exercise> saved = exerciseRepository.saveAll(exercises);
 
         return saved.stream()
-                .map(ex -> ExerciseResponseDto.builder()
-                        .id(ex.getId())
-                        .name(ex.getName())
-                        .sets(ex.getSets())
-                        .reps(ex.getReps())
-                        .weight(ex.getWeight())
-                        .muscleGroup(ex.getMuscleGroup())
-                        .workoutId(ex.getWorkout().getId())
-                        .build())
-                .collect(Collectors.toList());
+                .map(ex -> {
+                    String name = ex.getExerciseCatalog() != null
+                            ? ex.getExerciseCatalog().getName()
+                            : ex.getCustomExercise().getName();
+
+                    return ExerciseResponseDto.builder()
+                            .id(ex.getId())
+                            .name(name)
+                            .sets(ex.getSets())
+                            .reps(ex.getReps())
+                            .weight(ex.getWeight())
+                            .muscleGroup(ex.getExerciseCatalog() != null
+                                    ? ex.getExerciseCatalog().getMuscleGroup()
+                                    : ex.getCustomExercise().getMuscleGroup())
+                            .workoutId(ex.getWorkout().getId())
+                            .build();
+                }).collect(Collectors.toList());
     }
 
     public ExerciseResponseDto updateExercise(UUID id, UUID userId, ExerciseUpdateRequestDto request) throws AccessDeniedException {
@@ -72,21 +109,45 @@ public class ExerciseService {
             throw new AccessDeniedException("You do not have permission to update this exercise");
         }
 
-        if(request.getName() != null) existingExercise.setName(request.getName());
+        if(request.getCatalogId() != null && request.getCustomId() != null){
+            throw new IllegalArgumentException("Only one of catalogId or customId must be provided.");
+        }
+
+        if(request.getCatalogId() != null){
+            ExerciseCatalog catalog = exerciseCatalogRepository.findById(request.getCatalogId())
+                    .orElseThrow(() -> new NoSuchElementException("Catalog exercise not found"));
+            existingExercise.setExerciseCatalog(catalog);
+            existingExercise.setCustomExercise(null);
+        } else if(request.getCustomId() != null){
+            CustomExercise custom = customExerciseRepository.findById(request.getCustomId())
+                    .orElseThrow(() -> new NoSuchElementException("Custom exercise not found"));
+            existingExercise.setCustomExercise(custom);
+            existingExercise.setExerciseCatalog(null);
+        }
+
+
         if(request.getSets() != null) existingExercise.setSets(request.getSets());
         if(request.getReps() != null) existingExercise.setReps(request.getReps());
         if(request.getWeight() != null) existingExercise.setWeight(request.getWeight());
-        if(request.getMuscleGroup() != null) existingExercise.setMuscleGroup(request.getMuscleGroup());
+
 
         Exercise saved = exerciseRepository.save(existingExercise);
 
+        String name = saved.getExerciseCatalog() != null
+                ? saved.getExerciseCatalog().getName()
+                : saved.getCustomExercise().getName();
+
+        MuscleGroup muscleGroup = saved.getExerciseCatalog() != null
+                ? saved.getExerciseCatalog().getMuscleGroup()
+                : saved.getCustomExercise().getMuscleGroup();
+
         return ExerciseResponseDto.builder()
                 .id(saved.getId())
-                .name(saved.getName())
+                .name(name)
                 .sets(saved.getSets())
                 .reps(saved.getReps())
                 .weight(saved.getWeight())
-                .muscleGroup(saved.getMuscleGroup())
+                .muscleGroup(muscleGroup)
                 .workoutId(saved.getWorkout().getId())
                 .build();
 
@@ -114,15 +175,20 @@ public class ExerciseService {
                 endDate != null ? endDate : LocalDate.now()
         );
 
-        List<ExerciseProgressResponseDto> response = exercises.stream().map(e -> ExerciseProgressResponseDto.builder()
-                .date(e.getWorkout().getSessionDate())
-                .name(e.getName())
-                .sets(e.getSets())
-                .reps(e.getReps())
-                .weight(e.getWeight())
-                .volume(e.getSets()*e.getReps()*e.getWeight())
-                .build())
-                .toList();
+        List<ExerciseProgressResponseDto> response = exercises.stream().map(e -> {
+            String exerciseName = e.getExerciseCatalog() != null
+                    ? e.getExerciseCatalog().getName()
+                    : e.getCustomExercise().getName();
+
+                   return ExerciseProgressResponseDto.builder()
+                            .date(e.getWorkout().getSessionDate())
+                            .name(exerciseName)
+                            .sets(e.getSets())
+                            .reps(e.getReps())
+                            .weight(e.getWeight())
+                            .volume(e.getSets() * e.getReps() * e.getWeight())
+                            .build();
+                }).toList();
 
         return response;
     }

--- a/src/main/java/com/faiyaz/project/fittrack/workout/service/WorkoutService.java
+++ b/src/main/java/com/faiyaz/project/fittrack/workout/service/WorkoutService.java
@@ -107,7 +107,9 @@ public class WorkoutService {
                         .filter(e -> {
                             MuscleGroup muscle = e.getExerciseCatalog() != null
                                     ? e.getExerciseCatalog().getMuscleGroup()
-                                    : e.getCustomExercise().getMuscleGroup();
+                                    : e.getCustomExercise() != null
+                                        ? e.getCustomExercise().getMuscleGroup()
+                                        : null;
 
                             return muscle == muscleGroup;
                         })

--- a/src/main/java/com/faiyaz/project/fittrack/workout/service/WorkoutService.java
+++ b/src/main/java/com/faiyaz/project/fittrack/workout/service/WorkoutService.java
@@ -104,16 +104,31 @@ public class WorkoutService {
 
             if(muscleGroup != null){
                 exercises = exercises.stream()
-                        .filter(e -> e.getMuscleGroup() == muscleGroup)
+                        .filter(e -> {
+                            MuscleGroup muscle = e.getExerciseCatalog() != null
+                                    ? e.getExerciseCatalog().getMuscleGroup()
+                                    : e.getCustomExercise().getMuscleGroup();
+
+                            return muscle == muscleGroup;
+                        })
                         .toList();
             }
 
             return new WorkoutWithExercisesResponseDto(
                     workout.getSessionDate(),
                     exercises.stream()
-                            .map(e -> new ExerciseResponseDto(
-                                    e.getId(), e.getName(), e.getSets(), e.getReps(), e.getWeight(), e.getMuscleGroup(), e.getWorkout().getId()
-                            )).toList()
+                            .map(e -> {
+                                String name = e.getExerciseCatalog() != null
+                                        ? e.getExerciseCatalog().getName()
+                                        : e.getCustomExercise().getName();
+
+                                MuscleGroup muscle = e.getExerciseCatalog() != null
+                                        ? e.getExerciseCatalog().getMuscleGroup()
+                                        : e.getCustomExercise().getMuscleGroup();
+                                return new ExerciseResponseDto(
+                                        e.getId(), name, e.getSets(), e.getReps(), e.getWeight(), muscle, e.getWorkout().getId()
+                                );
+                            }).toList()
             );
         }).filter(w -> !w.getExercises().isEmpty()).toList();
 


### PR DESCRIPTION
This PR refactors the Exercise entity to reference either a global ExerciseCatalog or a user-defined CustomExercise. This enables more accurate tracking, reduces duplication, and supports a better user experience in both frontend and backend.