### PR TITLE
Refactor Exercise Entity to Support Set-Based Logging

### DIFF
--- a/src/main/java/com/faiyaz/project/fittrack/exercise/controller/ExerciseController.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/controller/ExerciseController.java
@@ -1,10 +1,8 @@
 package com.faiyaz.project.fittrack.exercise.controller;
 
-import com.faiyaz.project.fittrack.exercise.dto.ExerciseProgressResponseDto;
-import com.faiyaz.project.fittrack.exercise.dto.ExerciseRequestDto;
-import com.faiyaz.project.fittrack.exercise.dto.ExerciseResponseDto;
-import com.faiyaz.project.fittrack.exercise.dto.ExerciseUpdateRequestDto;
+import com.faiyaz.project.fittrack.exercise.dto.*;
 import com.faiyaz.project.fittrack.exercise.service.ExerciseService;
+import com.faiyaz.project.fittrack.exercise.service.ExerciseSetService;
 import com.faiyaz.project.fittrack.user.entity.User;
 import org.apache.coyote.Response;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -22,14 +20,18 @@ import java.util.UUID;
 public class ExerciseController {
 
     private final ExerciseService exerciseService;
+    private final ExerciseSetService setService;
 
-    public ExerciseController(ExerciseService exerciseService) {
+    public ExerciseController(ExerciseService exerciseService,
+                              ExerciseSetService setService) {
         this.exerciseService = exerciseService;
+        this.setService = setService;
     }
 
     @PostMapping
-    public ResponseEntity<List<ExerciseResponseDto>> addExercises(@RequestBody ExerciseRequestDto request){
-        List<ExerciseResponseDto> saved = exerciseService.addExerciseToWorkout(request);
+    public ResponseEntity<List<ExerciseResponseDto>> addExercises(@RequestBody ExerciseRequestDto request,
+                                                                  @AuthenticationPrincipal User user) throws AccessDeniedException {
+        List<ExerciseResponseDto> saved = exerciseService.addExerciseToWorkout(request, user.getId());
         return ResponseEntity.ok(saved);
     }
 
@@ -59,5 +61,19 @@ public class ExerciseController {
     ) {
         List<ExerciseProgressResponseDto> response = exerciseService.getExerciseProgress(user.getId(), name, startDate, endDate);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/sets/{setId}")
+    public ResponseEntity<ExerciseResponseDto.SetResponse> updateSet(@PathVariable UUID setId,
+                                       @AuthenticationPrincipal User user,
+                                       @RequestBody SetUpdateRequestDto request) throws AccessDeniedException {
+        return ResponseEntity.ok(setService.updateSingleSet(setId, user.getId(), request));
+    }
+
+    @DeleteMapping("/sets/{setId}")
+    public ResponseEntity<?> deleteSet(@PathVariable UUID setId,
+                                       @AuthenticationPrincipal User user) throws AccessDeniedException {
+        setService.deleteSet(setId, user.getId());
+        return  ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseProgressResponseDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseProgressResponseDto.java
@@ -3,6 +3,7 @@ package com.faiyaz.project.fittrack.exercise.dto;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Setter
@@ -12,8 +13,6 @@ import java.time.LocalDate;
 public class ExerciseProgressResponseDto {
     private LocalDate date;
     private String name;
-    private int sets;
-    private int reps;
-    private double weight;
+    private List<ExerciseResponseDto.SetResponse> sets;
     private double volume;
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseRequestDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseRequestDto.java
@@ -25,8 +25,16 @@ public class ExerciseRequestDto {
     public static class ExerciseInput {
         private UUID catalogId;
         private UUID customId;
-        private int sets;
-        private int reps;
-        private double weight;
+        private List<SetInput> sets;
+
+        @Getter
+        @Setter
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class SetInput {
+            private Integer reps;
+            private Double weight;
+            private String notes;
+        }
     }
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseResponseDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/ExerciseResponseDto.java
@@ -4,6 +4,7 @@ import com.faiyaz.project.fittrack.exercise.entity.MuscleGroup;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -15,9 +16,19 @@ public class ExerciseResponseDto {
 
     private UUID id;
     private String name;
-    private int sets;
-    private int reps;
-    private double weight;
+    private List<SetResponse> sets;
     private MuscleGroup muscleGroup;
     private UUID workoutId;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SetResponse {
+        private UUID id;
+        private int reps;
+        private double weight;
+        private String notes;
+        private LocalDateTime loggedAt;
+    }
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/dto/SetUpdateRequestDto.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/dto/SetUpdateRequestDto.java
@@ -1,20 +1,18 @@
 package com.faiyaz.project.fittrack.exercise.dto;
 
-import com.faiyaz.project.fittrack.exercise.entity.MuscleGroup;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
-public class ExerciseUpdateRequestDto {
-    private UUID catalogId;
-    private UUID customId;
-
+@NoArgsConstructor
+public class SetUpdateRequestDto {
+    private Integer reps;
+    private Double weight;
+    private String notes;
 }

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/entity/Exercise.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/entity/Exercise.java
@@ -7,6 +7,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -26,8 +28,8 @@ public class Exercise {
     @JoinColumn(name = "workout_id", nullable = false)
     private Workout workout;
 
-//    @Column(nullable = false)
-//    private String name;
+    @OneToMany(mappedBy = "exercise", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExerciseSet> sets = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "catalog_id")

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/entity/Exercise.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/entity/Exercise.java
@@ -1,6 +1,7 @@
 package com.faiyaz.project.fittrack.exercise.entity;
 
 import com.faiyaz.project.fittrack.workout.entity.Workout;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -29,6 +30,7 @@ public class Exercise {
     private Workout workout;
 
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<ExerciseSet> sets = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -38,19 +40,6 @@ public class Exercise {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "custom_id")
     private CustomExercise customExercise;
-
-    @Column(nullable = false)
-    private int sets;
-
-    @Column(nullable = false)
-    private int reps;
-
-    @Column(nullable = false)
-    private double weight;
-
-//    @Enumerated(EnumType.STRING)
-//    @Column(nullable = false)
-//    private MuscleGroup muscleGroup;
 
     @CreationTimestamp
     private LocalDateTime createdAt;

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/entity/ExerciseSet.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/entity/ExerciseSet.java
@@ -1,5 +1,6 @@
 package com.faiyaz.project.fittrack.exercise.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,6 +22,7 @@ public class ExerciseSet {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "exercise_id", nullable = false)
+    @JsonBackReference
     private Exercise exercise;
 
     @Column(nullable = false)

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/entity/ExerciseSet.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/entity/ExerciseSet.java
@@ -1,0 +1,44 @@
+package com.faiyaz.project.fittrack.exercise.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "exercise_sets")
+public class ExerciseSet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "exercise_id", nullable = false)
+    private Exercise exercise;
+
+    @Column(nullable = false)
+    private int reps;
+
+    @Column(nullable = false)
+    private double weight;
+
+    @Column(length = 255)
+    private String notes;
+
+    @Column(nullable = false)
+    private LocalDateTime loggedAt;
+
+    @PrePersist
+    public void prePersist(){
+        if(this.loggedAt == null){
+            this.loggedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/repository/ExerciseSetRepository.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/repository/ExerciseSetRepository.java
@@ -1,0 +1,11 @@
+package com.faiyaz.project.fittrack.exercise.repository;
+
+import com.faiyaz.project.fittrack.exercise.entity.ExerciseSet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ExerciseSetRepository extends JpaRepository<ExerciseSet, UUID> {
+}

--- a/src/main/java/com/faiyaz/project/fittrack/exercise/service/ExerciseSetService.java
+++ b/src/main/java/com/faiyaz/project/fittrack/exercise/service/ExerciseSetService.java
@@ -1,0 +1,56 @@
+package com.faiyaz.project.fittrack.exercise.service;
+
+import com.faiyaz.project.fittrack.exercise.dto.ExerciseResponseDto;
+import com.faiyaz.project.fittrack.exercise.dto.SetUpdateRequestDto;
+import com.faiyaz.project.fittrack.exercise.entity.ExerciseSet;
+import com.faiyaz.project.fittrack.exercise.repository.ExerciseSetRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.AccessDeniedException;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class ExerciseSetService {
+
+    private final ExerciseSetRepository exerciseSetRepository;
+
+    public ExerciseSetService(ExerciseSetRepository exerciseSetRepository) {
+        this.exerciseSetRepository = exerciseSetRepository;
+    }
+
+    @Transactional
+    public ExerciseResponseDto.SetResponse updateSingleSet(UUID setId, UUID userId, SetUpdateRequestDto request) throws AccessDeniedException {
+        ExerciseSet existingSet = exerciseSetRepository.findById(setId)
+                .orElseThrow(() -> new NoSuchElementException("Set not found"));
+
+        if(!existingSet.getExercise().getWorkout().getUser().getId().equals(userId)){
+            throw new AccessDeniedException("You do not have permission to update this set");
+        }
+
+        if(request.getReps() != null) existingSet.setReps(request.getReps());
+        if(request.getWeight() != null) existingSet.setWeight(request.getWeight());
+        if(request.getNotes() != null) existingSet.setNotes(request.getNotes());
+
+        ExerciseSet saved = exerciseSetRepository.save(existingSet);
+
+        return new ExerciseResponseDto.SetResponse(
+                saved.getId(),
+                saved.getReps(),
+                saved.getWeight(),
+                saved.getNotes(),
+                saved.getLoggedAt());
+    }
+
+    public void deleteSet(UUID setId, UUID userId) throws AccessDeniedException {
+        ExerciseSet set = exerciseSetRepository.findById(setId)
+                .orElseThrow(() -> new NoSuchElementException("Set not found"));
+
+        if(!set.getExercise().getWorkout().getUser().getId().equals(userId)){
+            throw new AccessDeniedException("You do not have permission to delete this set");
+        }
+
+        exerciseSetRepository.delete(set);
+    }
+}

--- a/src/main/java/com/faiyaz/project/fittrack/workout/service/WorkoutService.java
+++ b/src/main/java/com/faiyaz/project/fittrack/workout/service/WorkoutService.java
@@ -127,8 +127,12 @@ public class WorkoutService {
                                 MuscleGroup muscle = e.getExerciseCatalog() != null
                                         ? e.getExerciseCatalog().getMuscleGroup()
                                         : e.getCustomExercise().getMuscleGroup();
+
+                                List<ExerciseResponseDto.SetResponse> sets = e.getSets().stream()
+                                        .map(s -> new ExerciseResponseDto.SetResponse(s.getId(), s.getReps(), s.getWeight(), s.getNotes(), s.getLoggedAt()))
+                                        .toList();
                                 return new ExerciseResponseDto(
-                                        e.getId(), name, e.getSets(), e.getReps(), e.getWeight(), muscle, e.getWorkout().getId()
+                                        e.getId(), name, sets, muscle, e.getWorkout().getId()
                                 );
                             }).toList()
             );


### PR DESCRIPTION
This PR refactors the Exercise model to support logging multiple sets per exercise, each with distinct reps, weight, and notes.

Added ExerciseSet entity
Updated request/response DTOs
Rewrote add, update, and delete logic accordingly
Adjusted progress calculation logic
Tested all endpoints post-refactor